### PR TITLE
Adjust timestamp-difference to address DST boundary

### DIFF
--- a/timestamp.lisp
+++ b/timestamp.lisp
@@ -8,6 +8,8 @@
                 (local-time:sec-of time-b)))
         (nsec (- (local-time:nsec-of time-a)
                  (local-time:nsec-of time-b))))
+    (incf sec (- (lt::timestamp-subtimezone time-a timezone)
+		 (lt::timestamp-subtimezone time-b timezone)))
     (duration :day day :sec sec :nsec nsec)))
 
 (defun timestamp-duration+ (timestamp duration)


### PR DESCRIPTION
With the current implementation of local-time the timestamp-duration+ and timestamp-duration- operations will adjust the result when it crosses a DST boundary.  However timestamp-difference does not.  This results in the following, which feels inconsistent to me.

(setf test-diff (start end) 
(ltd::timestamp-duration+

(let ((start @2014-11-02T00:00:00.000000-05:00)
      (end @2014-11-03T00:00:00.000000-06:00))
   (ltd::timestamp-duration+
       start (ltd::timestamp-difference end start)))

=> @2014-11-03T01:00:00.000000-06:00
