### PR TITLE
Adjust timestamp-difference to address DST boundary

### DIFF
--- a/timestamp.lisp
+++ b/timestamp.lisp
@@ -1,11 +1,8 @@
 (in-package :ltd)
 
-(defun timestamp-difference (time-a time-b &key (timezone lt::*default-timezone*))
+(defun timestamp-difference (time-a time-b)
   "Returns a duration representing the time elapsed between the timestamps `TIME-A` and `TIME-B`. This duration may be negative if `TIME-B` is later than `TIME-A`."
   (let ((seconds (- (lt:timestamp-to-universal time-a) (lt:timestamp-to-universal time-b))))
-    #+nil(when lt:*use-political-time*
-      (incf seconds (- (lt::timestamp-subtimezone time-a timezone)
-		   (lt::timestamp-subtimezone time-b timezone))))    
     (duration :sec seconds)))
 
 (defun timestamp-duration+ (timestamp duration)


### PR DESCRIPTION
With the current implementation of local-time, the timestamp-duration+ and timestamp-duration- operations will adjust the resulting timestamp is on the other side of  a DST boundary.  However timestamp-difference does not take DST into account.  This results in the following, which feels inconsistent to me.

> (test-diff @2014-11-02T00:00:00.000000-05:00  @2014-11-03T00:00:00.000000-06:00)
> @2014-11-03T01:00:00.000000-06:00
> (test-diff @2015-03-08T00:00:00.000000-06:00 @2015-03-09T00:00:00.000000-05:00)
> @2015-03-08T23:00:00.000000-05:00

After the proposed change the results are as follows:

> (test-diff @2014-11-02T00:00:00.000000-05:00  @2014-11-03T00:00:00.000000-06:00)
> @2014-11-03T00:00:00.000000-06:00
> (test-diff @2015-03-08T00:00:00.000000-06:00 @2015-03-09T00:00:00.000000-05:00)
> @2015-03-09T00:00:00.000000-05:00
