### PR TITLE
Add readable printing for duration objects

### DIFF
--- a/format.lisp
+++ b/format.lisp
@@ -45,9 +45,21 @@ ignored."
                     (zero-is-nil nsecs)))))))
 
 (defmethod print-object ((object duration) stream)
-  (print-unreadable-object (object stream :type 'duration)
-    (format stream "[~d/~d/~d] ~A"
-            (day-of object)
-            (sec-of object)
-            (nsec-of object)
-            (human-readable-duration object))))
+  (if *print-readably*
+      ;; According to DECODE-DURATION, the YEAR, MONTHS and WEEKS
+      ;; components are always zero.
+      (multiple-value-bind (nsecs secs minutes hours days)
+          (decode-duration object)
+        (flet ((field (key value) (if (zerop value) () (list key value))))
+          (format stream "#.~S"
+                  `(duration ,@(field :day days)
+                             ,@(field :hour hours)
+                             ,@(field :minute minutes)
+                             ,@(field :sec secs)
+                             ,@(field :nsec nsecs)))))
+      (print-unreadable-object (object stream :type 'duration)
+        (format stream "[~d/~d/~d] ~A"
+                (day-of object)
+                (sec-of object)
+                (nsec-of object)
+                (human-readable-duration object)))))


### PR DESCRIPTION
For example:

```
CL-USER> (write (local-time-duration:duration :hour 3) :readably t)
#.(LOCAL-TIME-DURATION:DURATION :HOUR 3)
#<LOCAL-TIME-DURATION:DURATION [0/10800/0]  3 hours>

```