### PR TITLE
Function human-readable-duration now outputs only two significant parts by default.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+1.2 (2019-05-10)
+
+	Function human-readable-duration now outputs only two significant parts by default.
+	But this can be configurable by second optional argument.
+
+	Also, third optional argument was added to add ability to translate representation into
+	other languages. See README for example.
+
 1.1 (2018-04-24)
 
 	Added support for printing readable representations of durations.

--- a/format.lisp
+++ b/format.lisp
@@ -29,20 +29,61 @@ ignored."
       (format nil "~F" (float (+ secs (/ nsecs +nsecs-per-second+))))
       (format nil "~D" secs)))
 
-(defun human-readable-duration (duration &optional stream)
+(defun human-readable-duration (duration &optional stream (n-parts 2))
+  (check-type n-parts (integer 1 6))
+  
   (multiple-value-bind (nsecs secs minutes hours days weeks)
-      (decode-duration duration :weeks t)
-    (flet ((zero-is-nil (x) (if (zerop x) nil x)))
-      (with-designated-stream (stream stream)
-        (if (every #'zerop (list weeks days hours minutes secs nsecs))
+      (local-time-duration::decode-duration duration :weeks t)
+    (flet ((zero-is-nil (x)
+             (if (zerop x) nil x)))
+      (local-time-duration::with-designated-stream (stream stream)
+        (let ((args (loop for item in (list weeks days hours minutes secs nsecs)
+                          for idx upfrom 0
+                          if (>= idx n-parts)
+                            collect nil
+                          else
+                            collect (zero-is-nil item))))
+          (if (every #'null args)
+              (format stream "0 length")
+              (apply #'format
+                     stream
+                     "~@[~d week~:p~]~@[ ~d day~:p~]~@[ ~d hour~:p~]~@[ ~d minute~:p~]~@[ ~d second~:p~]~@[ ~d nsec~:p~]"
+                     args)))))))
+
+(defun default-format-part (stream part-type part)
+  "This is default function, define your own if you want to support other language."
+  (ecase part-type
+    (:weeks (format stream "~d week~:p" part))
+    (:days (format stream "~d day~:p" part))
+    (:hours (format stream "~d hour~:p" part))
+    (:minutes (format stream "~d minute~:p" part))
+    (:secs (format stream "~d second~:p" part))
+    (:nsecs (format stream "~d nsec~:p" part))))
+
+(defun human-readable-duration (duration &optional stream (n-parts 2) (format-part #'default-format-part))
+  (check-type n-parts (integer 1 6))
+  
+  (multiple-value-bind (nsecs secs minutes hours days weeks)
+      (local-time-duration::decode-duration duration :weeks t)
+    (local-time-duration::with-designated-stream (stream stream)
+      (let ((part-types (list :weeks :days :hours :minutes :secs :nsecs))
+            (parts (list weeks days hours minutes secs nsecs)))
+        (if (every #'zerop parts)
             (format stream "0 length")
-            (format stream "~@[~d week~:p~]~@[ ~d day~:p~]~@[ ~d hour~:p~]~@[ ~d minute~:p~]~@[ ~d second~:p~]~@[ ~d nsec~:p~]"
-                    (zero-is-nil weeks)
-                    (zero-is-nil days)
-                    (zero-is-nil hours)
-                    (zero-is-nil minutes)
-                    (zero-is-nil secs)
-                    (zero-is-nil nsecs)))))))
+            (loop with n-printed = 0
+                  for part in parts
+                  for part-type in part-types
+                  unless (zerop part)
+                    do (unless (zerop n-printed)
+                         ;; Add a space between parts
+                         (format stream " "))
+                       (funcall format-part
+                                stream
+                                part-type
+                                part)
+                       (incf n-printed)
+                  when (>= n-printed n-parts)
+                    do (return)))))))
 
 (defmethod print-object ((object duration) stream)
   (if *print-readably*

--- a/local-time-duration.asd
+++ b/local-time-duration.asd
@@ -3,7 +3,7 @@
 
 (defsystem :local-time-duration
     :description "local-time-duration: Simple duration functionality on top of local-time"
-    :version "1.1"
+    :version "1.2"
     :author "WebCheckout, Inc."
     :license "MIT"
     :depends-on (:local-time :alexandria :esrap)

--- a/readme.md
+++ b/readme.md
@@ -35,3 +35,44 @@ LTD> (duration-as (duration :day 1 :hour 4 :minute 25) :hour)
 LTD> (timestamp-difference @2014-01-01T09:00:00 @2014-01-01T06:00:00)
 #<DURATION [0/10800/0] 3 hours>
 ```
+
+### Printing
+
+Durations can be represented as human readable strings using `human-readable-duration` function:
+
+```
+LTD> (human-readable-duration (duration :week 42 :day 0 :hour 2 :minute 3 :sec 15 :nsec 214354))
+"42 weeks 2 hours"
+```
+
+First optional argument is a stream. Using second optional argument, you can set a number of parts to output:
+
+```
+LTD> (human-readable-duration (duration :week 42 :day 0 :hour 2 :minute 3 :sec 15 :nsec 214354)
+                              nil
+                              4)
+"42 weeks 2 hours 3 minutes 15 seconds"
+```
+
+Using third optional argument, you can add support for another language
+with proper pluralization:
+
+```
+LTD> (defun russian-format-part (stream part-type value)
+       (format stream
+               "~A ~A"
+               value
+               (ecase part-type
+                 (:weeks (cl-inflector:pluralize value "неделя" "недель"))
+                 (:days (cl-inflector:pluralize value "день" "дней"))
+                 (:hours (cl-inflector:pluralize value "час" "часов"))
+                 (:minutes (cl-inflector:pluralize value "минута" "минут"))
+                 (:secs (cl-inflector:pluralize value "секунда" "секунд"))
+                 (:nsecs (cl-inflector:pluralize value "наносекунда" "наносекунд")))))
+RUSSIAN-FORMAT-PART
+LTD> (human-readable-duration (duration :week 42 :day 0 :hour 2 :minute 3 :sec 15 :nsec 214354)
+                              nil
+                              4
+                              'russian-format-part)
+"42 недель 2 часов 3 минут 15 секунд"
+```


### PR DESCRIPTION
This can be configurable by second optional argument.

```
LTD> (human-readable-duration (duration :week 42 :day 0 :hour 2 :minute 3 :sec 15 :nsec 214354))
"42 weeks 2 hours"
```

instead of:
```
LTD> (human-readable-duration (duration :week 42 :day 0 :hour 2 :minute 3 :sec 15 :nsec 214354))
"42 weeks 2 hours 3 minutes 15 seconds 214354 nsecs"
```
Using second optional argument, you can set a number of parts to output:

```
LTD> (human-readable-duration (duration :week 42 :day 0 :hour 2 :minute 3 :sec 15 :nsec 214354)
                              nil
                              4)
"42 weeks 2 hours 3 minutes 15 seconds"
```
Using third optional argument, you can add support for another language
with proper pluralization:

```
LTD> (defun russian-format-part (stream part-type value)
       (format stream
               "~A ~A"
               value
               (ecase part-type
                 (:weeks (cl-inflector:pluralize value "неделя" "недель"))
                 (:days (cl-inflector:pluralize value "день" "дней"))
                 (:hours (cl-inflector:pluralize value "час" "часов"))
                 (:minutes (cl-inflector:pluralize value "минута" "минут"))
                 (:secs (cl-inflector:pluralize value "секунда" "секунд"))
                 (:nsecs (cl-inflector:pluralize value "наносекунда" "наносекунд")))))
RUSSIAN-FORMAT-PART
LTD> (human-readable-duration (duration :week 42 :day 0 :hour 2 :minute 3 :sec 15 :nsec 214354)
                              nil
                              4
                              'russian-format-part)
"42 недель 2 часов 3 минут 15 секунд"
```